### PR TITLE
Add delete method, dry up code a little, update example to use said delete method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Both API methods work on client and server.
 1. `options` (required) an object with options, described below.
 2. `callback(error, data)` (required) a callback that is called with two arguments, 'error', and 'data'.
     1. `error` a Meteor.Error describing the reason the photo could not be uploaded.
-    2. `data` an object that contains the response from the Imgur API, [documented here](https://api.imgur.com/models/image). The most useful property is `data.link`, which contains the URL of the newly uploaded image.
+    2. `data` an object that contains the response from the Imgur API, [documented here](https://api.imgur.com/models/image). The most useful properties are `data.link`, which contains the URL of the newly uploaded image, and `data.deletehash`, which contains the id used for deleting the image later on.
     
 #### Options
 
 - `apiKey` the Imgur Client ID. Get it by signing up for the API at <https://api.imgur.com/oauth2/addclient>.
-- `image` the image data, can a base64-encoded image data string or the URL of an image somewhere on the internet.
+- `image` the image data, can be a base64-encoded image data string or the URL of an image somewhere on the internet.
 - `mashapeKey` optional Mashape key, necessary for commercial use apps. If provided, the method will request to the mashape endpoint instead of the regular imgur one.
 - `type`, `name`, `title`, `description`, `album` optional properties exactly as documented at <https://api.imgur.com/endpoints/image#image-upload>.
 
@@ -40,3 +40,20 @@ Both API methods work on client and server.
     * `Imgur.MEDIUM_THUMBNAIL`
     * `Imgur.LARGE_THUMBNAIL`
     * `Imgur.HUGE_THUMBNAIL`
+
+---
+
+### Imgur.delete(options, callback)
+
+#### Arguments
+
+1. `options` (required) an object with options, described below.
+2. `callback(error, data)` (required) a callback that is called with two arguments, 'error', and 'data'.
+    1. `error` a Meteor.Error describing the reason the photo could not be deleted.
+    2. `data` an object that contains the response from the Imgur API, [documented here](https://api.imgur.com/models/basic). In this case, a boolean value.
+    
+#### Options
+
+- `apiKey` the Imgur Client ID. Get it by signing up for the API at <https://api.imgur.com/oauth2/addclient>.
+- `deleteHash` the delete hash, retrieved in the response object of the `upload` method
+- `mashapeKey` optional Mashape key, necessary for commercial use apps. If provided, the method will request to the mashape endpoint instead of the regular imgur one.

--- a/example/example.html
+++ b/example/example.html
@@ -4,10 +4,10 @@
 
 <body>
   <h1>Photo Booth</h1>
-  <button id="create">Take a photo and upload to Imgur!</button>
+  <button id="create" disabled={{waitingForApiResponse}}>Take a photo and upload to Imgur!</button>
 
   {{#if photoUrl}}
-  <button id="delete">Delete it!</button>
+  <button id="delete" disabled={{waitingForApiResponse}}>Delete it!</button>
     <div><img src="{{photoUrl}}" /></div>
 
     <h2>Thumbnails</h2>

--- a/example/example.html
+++ b/example/example.html
@@ -4,9 +4,10 @@
 
 <body>
   <h1>Photo Booth</h1>
-  <button>Take a photo and upload to Imgur!</button>
+  <button id="create">Take a photo and upload to Imgur!</button>
 
   {{#if photoUrl}}
+  <button id="delete">Delete it!</button>
     <div><img src="{{photoUrl}}" /></div>
 
     <h2>Thumbnails</h2>

--- a/example/example.js
+++ b/example/example.js
@@ -3,6 +3,9 @@ if (Meteor.isClient) {
     photoUrl: function () {
       return Session.get("photo");
     },
+    deleteHash: function () {
+      return Session.get("deleteHash");
+    },
     thumbSizes: ["s", "b", "t", "m"],
     thumb: function () {
       return Imgur.toThumbnail(Session.get("photo"), this.valueOf());
@@ -10,7 +13,8 @@ if (Meteor.isClient) {
   });
 
   Template.body.events({
-    'click button': function () {
+    'click button#create': function () {
+      $('button').prop('disabled', true);
       MeteorCamera.getPicture({
         width: 400,
         height: 300,
@@ -23,14 +27,32 @@ if (Meteor.isClient) {
             image: data,
             apiKey: Config.imgurApiKey
           }, function (error, data) {
+            $('button').prop('disabled', false);
             if (error) {
               throw error;
             } else {
               Session.set("photo", data.link);
+              Session.set("deleteHash", data.deletehash);
             }
           });
         }
       });
+    },
+    'click button#delete': function () {
+      $('button').prop('disabled', true);
+      Imgur.delete({
+        deleteHash: Session.get("deleteHash"),
+        apiKey: Config.imgurApiKey
+      }, function (error, data) {
+        $('button').prop('disabled', false);
+        if (error) {
+          throw error;
+        } else {
+          Session.set("photo", null);
+          Session.set("deleteHash", null);
+        }
+      });
+
     }
   });
 }

--- a/example/example.js
+++ b/example/example.js
@@ -6,6 +6,9 @@ if (Meteor.isClient) {
     deleteHash: function () {
       return Session.get("deleteHash");
     },
+    waitingForApiResponse: function () {
+      return Session.get("waitingForApiResponse");
+    },
     thumbSizes: ["s", "b", "t", "m"],
     thumb: function () {
       return Imgur.toThumbnail(Session.get("photo"), this.valueOf());
@@ -14,7 +17,7 @@ if (Meteor.isClient) {
 
   Template.body.events({
     'click button#create': function () {
-      $('button').prop('disabled', true);
+      Session.set('waitingForApiResponse', true);
       MeteorCamera.getPicture({
         width: 400,
         height: 300,
@@ -27,7 +30,7 @@ if (Meteor.isClient) {
             image: data,
             apiKey: Config.imgurApiKey
           }, function (error, data) {
-            $('button').prop('disabled', false);
+            Session.set('waitingForApiResponse', false);
             if (error) {
               throw error;
             } else {
@@ -39,12 +42,12 @@ if (Meteor.isClient) {
       });
     },
     'click button#delete': function () {
-      $('button').prop('disabled', true);
+      Session.set('waitingForApiResponse', true);
       Imgur.delete({
         deleteHash: Session.get("deleteHash"),
         apiKey: Config.imgurApiKey
       }, function (error, data) {
-        $('button').prop('disabled', false);
+        Session.set('waitingForApiResponse', false);
         if (error) {
           throw error;
         } else {


### PR DESCRIPTION
I think we can add the possibility to delete a picture using a nice `delete` method.

I was not too sure about how to dry up the API settings code (so it would not be redundant in both functions), so I created this anonymous function on top.

I also updated the example in order to use the delete method, but somehow on my machine it does not find my new delete function... you should maybe try it on your config.
